### PR TITLE
docker run -it runs /bin/bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ both the container and host OS.
 
 ```bash
 docker run -it --mount type=bind,source="$(pwd)",target=/workspaces \
-    ducksauz/esp-matter-dev:latest
+    ducksauz/esp-matter-dev:latest /bin/bash
 ```
 
 You should get some output that looks like this and then a root shell


### PR DESCRIPTION
This command from the README
```bash
docker run -it --mount type=bind,source="$(pwd)",target=/workspaces \
    ducksauz/esp-matter-dev:latest
```
is followed by
> You should get some output that looks like this and then a root shell prompt within the container.
and  then some  bash commands.

The command as is runs with no output and doesn't drop  into the container.

README run command is updated to 
```bash
docker run -it --mount type=bind,source="$(pwd)",target=/workspaces \
    ducksauz/esp-matter-dev:latest /bin/bash
```
which  gives the expected output and drops the  user  into  the container with a bash  prompt.